### PR TITLE
Add 10 second delay after agent init

### DIFF
--- a/main.go
+++ b/main.go
@@ -20,6 +20,9 @@ func main() {
 	)
 	defer agent.Close()
 
+	fmt.Println("-- Waiting for initialization --")
+	time.Sleep(10 * time.Second)
+
 	var client = &http.Client{
 		Timeout: time.Second * 10,
 	}


### PR DESCRIPTION
Environments are created asynchronously on the back-end. We must wait for that to happen so that all built-in rules have been created and sent to the agent.

This is a temporary measure until we fix this properly.